### PR TITLE
ZoL master and FreeBSD 11.2 support

### DIFF
--- a/libzfs-sys/list_gcc_include_paths.sh
+++ b/libzfs-sys/list_gcc_include_paths.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+gcc -Wp,-v -x c - -fsyntax-only < /dev/null 2>&1 | grep '^ ' | sed -e 's/^ //'

--- a/libzfs-sys/wrapper.h
+++ b/libzfs-sys/wrapper.h
@@ -4,4 +4,6 @@
 
 #define _LARGEFILE64_SOURCE
 
+#define NEED_SOLARIS_BOOLEAN
+
 #include <libzfs_impl.h>

--- a/libzfs/src/libzfs.rs
+++ b/libzfs/src/libzfs.rs
@@ -60,9 +60,7 @@ impl Libzfs {
     pub fn find_importable_pools(&mut self) -> nvpair::NvList {
         let _l = LOCK.lock().unwrap();
         unsafe {
-            sys::thread_init();
             let x = sys::zpool_find_import(self.raw, 0, ptr::null_mut());
-            sys::thread_fini();
 
             nvpair::NvList::from_ptr(x)
         }

--- a/libzfs/src/zfs.rs
+++ b/libzfs/src/zfs.rs
@@ -47,8 +47,8 @@ impl Zfs {
             sys::zfs_expand_proplist(
                 self.raw,
                 &mut prop_list_ptr,
-                sys::boolean::B_TRUE,
-                sys::boolean::B_TRUE,
+                sys::boolean_t::B_TRUE,
+                sys::boolean_t::B_TRUE,
             )
         };
 
@@ -62,7 +62,7 @@ impl Zfs {
         let pl = self.prop_list()?;
 
         let xs = pl.filter_map(|x: ZpropItem| match x.prop() {
-            sys::zfs_prop_t_ZFS_PROP_BAD => self.user_props()
+            sys::zfs_prop_t_ZPROP_INVAL => self.user_props()
                 .lookup_nv_list(x.user_prop())
                 .and_then(|nv| nv.lookup_string(sys::zprop_value()))
                 .map(|v| ZProp {
@@ -82,7 +82,7 @@ impl Zfs {
                         ptr::null_mut(),
                         ptr::null_mut(),
                         0,
-                        sys::boolean::B_TRUE,
+                        sys::boolean_t::B_TRUE,
                     )
                 };
 

--- a/libzfs/src/zpool.rs
+++ b/libzfs/src/zpool.rs
@@ -56,7 +56,7 @@ impl Zpool {
                 raw,
                 sys::ZPOOL_MAXPROPLEN as usize,
                 ptr::null_mut(),
-                sys::boolean::B_FALSE,
+                sys::boolean_t::B_FALSE,
             );
 
             let out = CString::from_raw(raw);
@@ -141,7 +141,7 @@ impl Zpool {
         }
     }
     pub fn disable_datasets(&self) -> Result<()> {
-        let code = unsafe { sys::zpool_disable_datasets(self.raw, sys::boolean::B_FALSE) };
+        let code = unsafe { sys::zpool_disable_datasets(self.raw, sys::boolean_t::B_FALSE) };
 
         match code {
             0 => Ok(()),
@@ -149,7 +149,7 @@ impl Zpool {
         }
     }
     pub fn export(&self) -> Result<()> {
-        let code = unsafe { sys::zpool_export(self.raw, sys::boolean::B_FALSE, ptr::null_mut()) };
+        let code = unsafe { sys::zpool_export(self.raw, sys::boolean_t::B_FALSE, ptr::null_mut()) };
 
         match code {
             0 => Ok(()),


### PR DESCRIPTION
I've updated the API to support `libzfs` as of zfsonlinux/zfs@2e5dc449c1a65e0b0bf730fd69c9b5804bd57ee8 (current `master`) which happens to coincide with the `libzfs` API as shipped in FreeBSD 11.2. I used Debian GNU/Linux 9 with kernel 4.9.88-1+deb9u1 and ZoL `master` to test on Linux. I generalized the Linux support in the build system to use the include paths in the `pkg-config` output and output from a small shell script which queries `gcc` to find the system include directories.

I haven't put a regenerated `libzfs-sys/src/bindings.rs` in this PR as my generated bindings don't seem to pretty-print and I haven't investigated why not.

A single code location (`libzfs-sys/build.rs:115`) presupposes the path to the ZFS source on Linux and assumes that you are running against the `master` of ZoL. Maybe this should be configurable via an environment variable or cargo parameter or similar.

Speaking of environment variables, I could not figure out how `env::set_var("LIBCLANG_PATH", "/opt/llvm-5.0.0/lib64/");` affects anything after reading <https://github.com/KyleMayes/clang-sys/blob/67f7d8c25eff694d7ba58ff42da6e5b502413b7d/README.md> and related source which only uses `LIBCLANG_PATH` at `clang-sys` build time.

The line `fn list_gcc_include_paths() -> impl Iterator<Item = PathBuf> {` uses a rust 1.26+ feature. I'm not sure what the previously preferred solution is to this usage if compatibility for rust < 1.26 is desired.

Probably the most confusing issue I had was with `boolean`/`boolean_t`. Use of `boolean` only seems to work if the declaration is `typedef enum boolean { ... } boolean_t` but I could only find `typedef enum { ... } boolean_t` forms in the version history. Using `boolean_t` is only slightly longer and appears to work universally after `NEED_SOLARIS_BOOLEAN` is declared for FreeBSD.

Closes #63.