### PR TITLE
Add more Error variants

### DIFF
--- a/libzfs/src/libzfs_error.rs
+++ b/libzfs/src/libzfs_error.rs
@@ -4,12 +4,14 @@
 
 use std::ffi::IntoStringError;
 use std::io::Error;
-use std::{error, fmt, result, str};
+use std::{error, fmt, result};
 
 #[derive(Debug)]
 pub enum LibZfsError {
     Io(::std::io::Error),
     IntoString(IntoStringError),
+    PoolNotFound(Option<String>, Option<u64>),
+    ZfsNotFound(String),
 }
 
 impl fmt::Display for LibZfsError {
@@ -17,22 +19,30 @@ impl fmt::Display for LibZfsError {
         match *self {
             LibZfsError::Io(ref err) => write!(f, "{}", err),
             LibZfsError::IntoString(ref err) => write!(f, "{}", err),
+            LibZfsError::PoolNotFound(ref pool, guid) => match (pool, guid) {
+                (Some(pool), Some(guid)) => write!(
+                    f,
+                    "The pool: {} with guid: {} could not be found.",
+                    pool, guid
+                ),
+                (Some(pool), None) => write!(f, "The pool: {} could not be found.", pool),
+                (None, Some(guid)) => write!(f, "The pool with guid: {} could not be found.", guid),
+                (None, None) => write!(f, "The pool could not be found."),
+            },
+            LibZfsError::ZfsNotFound(ref err) => {
+                write!(f, "The zfs object {} could not be found", err)
+            }
         }
     }
 }
 
 impl error::Error for LibZfsError {
-    fn description(&self) -> &str {
-        match *self {
-            LibZfsError::Io(ref err) => err.description(),
-            LibZfsError::IntoString(ref err) => err.description(),
-        }
-    }
-
     fn cause(&self) -> Option<&error::Error> {
         match *self {
             LibZfsError::Io(ref err) => Some(err),
             LibZfsError::IntoString(ref err) => Some(err),
+            LibZfsError::PoolNotFound(_, _) => None,
+            LibZfsError::ZfsNotFound(_) => None,
         }
     }
 }

--- a/libzfs/src/vdev.rs
+++ b/libzfs/src/vdev.rs
@@ -11,7 +11,7 @@ use std::io::{Error, ErrorKind};
 
 /// Represents vdevs
 /// The enum starts at Root and is recursive.
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Clone)]
 pub enum VDev {
     Mirror {
         children: Vec<VDev>,

--- a/libzfs/src/zprop_list.rs
+++ b/libzfs/src/zprop_list.rs
@@ -52,7 +52,7 @@ impl ZpropItem {
     }
 }
 
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Deserialize, Serialize, Clone)]
 pub struct ZProp {
     pub name: String,
     pub value: String,


### PR DESCRIPTION
Add two new error variants, `PoolNotFound` and `ZfsNotFound`.

By doing this, we can return not found results when getting pools and
datasets, instead of a `Result` nested inside an `Option`.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>