### PR TITLE
Add libzfs types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ jobs:
           script:
               - docker run -d -it --name libzfs -v $(pwd):/rust-libzfs:rw imlteam/zfs
               - docker exec -i libzfs bash -c "cd /rust-libzfs/libzfs && cargo package && cargo publish --token $CARGO_TOKEN"
+        - stage: deploy-libzfs-types
+          name: "libzfs-types"
+          script:
+              - docker run -d -it --name libzfs -v $(pwd):/rust-libzfs:rw imlteam/zfs
+              - docker exec -i libzfs bash -c "cd /rust-libzfs/libzfs-types && cargo package && cargo publish --token $CARGO_TOKEN"
         - stage: deploy-node-libzfs
           name: "@iml/node-libzfs"
           language: node_js
@@ -56,6 +61,8 @@ stages:
       if: branch =~ ^v\d+\.\d+\.\d+libzfs-sys$
     - name: deploy-libzfs
       if: branch =~ ^v\d+\.\d+\.\d+libzfs$
+    - name: deploy-libzfs-types
+      if: branch =~ ^v\d+\.\d+\.\d+libzfs-types$
     - name: deploy-node-libzfs
       if: branch =~ ^v\d+\.\d+\.\d+node-libzfs$
     - name: deploy-copr

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,21 +26,21 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.43.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cexpr 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "clang-sys 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -69,7 +69,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clang-sys"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -108,7 +108,7 @@ dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -140,11 +140,8 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "libc"
@@ -166,8 +163,9 @@ version = "0.6.11"
 dependencies = [
  "cstr-argument 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libzfs-sys 0.5.7",
+ "libzfs-types 0.1.0",
  "nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -177,9 +175,17 @@ dependencies = [
 name = "libzfs-sys"
 version = "0.5.7"
 dependencies = [
- "bindgen 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bindgen 0.43.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nvpair-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libzfs-types"
+version = "0.1.0"
+dependencies = [
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -275,19 +281,19 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -354,7 +360,7 @@ name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -435,12 +441,12 @@ dependencies = [
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
-"checksum bindgen 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41df015ccbc22b038641bd84d0aeeff01e0a4c0714ed35ed0e9a3dd8ad8d732"
+"checksum bindgen 0.43.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49a944a85a9f2a49c602cad1e87cebe90963190d8a3c12101f608300f2210f2f"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cexpr 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fc0086be9ca82f7fc89fc873435531cb898b86e850005850de1f820e2db6e9b"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
-"checksum clang-sys 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)" = "481e42017c1416b1c0856ece45658ecbb7c93d8a93455f7e5fa77f3b35455557"
+"checksum clang-sys 0.26.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1de610566438a6f9e60515a198bb6830fcea8c3bbe8fb83d50c82c83624e6e3b"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cstr-argument 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22fab941bd464955e5cbeb59816a39b26ab6867942b3e6d3c28cd98ed01acded"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
@@ -448,7 +454,7 @@ dependencies = [
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
-"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
@@ -464,8 +470,8 @@ dependencies = [
 "checksum quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "63b5829244f52738cfee93b3a165c1911388675be000c888d2fae620dee8fa5b"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
-"checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
+"checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
+"checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
 "checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ['libzfs-sys', 'libzfs']
+members = ['libzfs-sys', 'libzfs', 'libzfs-types']
 exclude = ['node-libzfs']

--- a/libzfs-sys/Cargo.toml
+++ b/libzfs-sys/Cargo.toml
@@ -12,5 +12,5 @@ build = "build.rs"
 nvpair-sys = "0.1"
 
 [build-dependencies]
-bindgen = "0.43.0"
+bindgen = "0.43.1"
 pkg-config = "0.3.14"

--- a/libzfs-sys/build.rs
+++ b/libzfs-sys/build.rs
@@ -16,7 +16,10 @@ fn main() {
 
     env::set_var("LIBCLANG_PATH", "/opt/llvm-5.0.0/lib64/");
 
-    pkg_config::Config::new().probe("libzfs").unwrap();
+    pkg_config::Config::new()
+        .atleast_version("0.7.9")
+        .probe("libzfs")
+        .unwrap();
     println!("cargo:rustc-link-lib=zpool");
 
     // Skip building if bindings already exist.

--- a/libzfs-types/Cargo.toml
+++ b/libzfs-types/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "libzfs-types"
+version = "0.1.0"
+authors = ["IML Team <iml@whamcloud.com>"]
+description = "Shared types for libzfs"
+license = "MIT"
+
+[dependencies]
+serde = "1.0"
+serde_derive = "1.0"

--- a/libzfs-types/src/lib.rs
+++ b/libzfs-types/src/lib.rs
@@ -1,0 +1,76 @@
+// Copyright (c) 2018 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+//! libzfs-types — Shared types for libzfs
+//!
+
+extern crate serde_derive;
+
+use serde_derive::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Clone)]
+pub enum VDev {
+    Mirror {
+        children: Vec<VDev>,
+        is_log: Option<bool>,
+    },
+    RaidZ {
+        children: Vec<VDev>,
+    },
+    Replacing {
+        children: Vec<VDev>,
+    },
+    Root {
+        children: Vec<VDev>,
+        spares: Vec<VDev>,
+        cache: Vec<VDev>,
+    },
+    Disk {
+        guid: Option<u64>,
+        state: String,
+        path: PathBuf,
+        dev_id: Option<String>,
+        phys_path: Option<String>,
+        whole_disk: Option<bool>,
+        is_log: Option<bool>,
+    },
+    File {
+        guid: Option<u64>,
+        state: String,
+        path: PathBuf,
+        is_log: Option<bool>,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Deserialize, Serialize, Clone)]
+pub struct ZProp {
+    pub name: String,
+    pub value: String,
+}
+
+/// A Pool at a point in time
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Pool {
+    pub name: String,
+    pub guid: u64,
+    pub health: String,
+    pub hostname: String,
+    pub hostid: Option<u64>,
+    pub state: String,
+    pub readonly: bool,
+    pub size: String,
+    pub vdev: VDev,
+    pub props: Vec<ZProp>,
+    pub datasets: Vec<Dataset>,
+}
+
+/// A Dataset at a point in time
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Dataset {
+    pub name: String,
+    pub guid: String,
+    pub kind: String,
+    pub props: Vec<ZProp>,
+}

--- a/libzfs/Cargo.toml
+++ b/libzfs/Cargo.toml
@@ -6,7 +6,8 @@ description = "Rust wrapper around libzfs-sys"
 license = "MIT"
 
 [dependencies]
-libzfs-sys = { path = "../libzfs-sys", version = "0.5.7" }
+libzfs-sys = { path = "../libzfs-sys", version = "0.5.7"}
+libzfs-types = { path = "../libzfs-types", version = "0.1.0" }
 nvpair-sys = "0.1"
 serde = "1.0"
 serde_derive = "1.0"

--- a/libzfs/src/lib.rs
+++ b/libzfs/src/lib.rs
@@ -5,7 +5,6 @@
 //! libzfs — Rusty wrapper around libzfs-sys.
 //!
 
-#[macro_use]
 extern crate serde_derive;
 
 #[macro_use]
@@ -15,6 +14,8 @@ extern crate foreign_types;
 extern crate lazy_static;
 
 extern crate libzfs_sys as sys;
+
+extern crate libzfs_types;
 
 mod nvpair;
 

--- a/libzfs/src/state.rs
+++ b/libzfs/src/state.rs
@@ -12,35 +12,9 @@ use std::io;
 
 use libzfs::Libzfs;
 use libzfs_error::{LibZfsError, Result};
-use vdev::VDev;
+use libzfs_types::{Dataset, Pool};
 use zfs::Zfs;
 use zpool::Zpool;
-use zprop_list::ZProp;
-
-/// A Pool at a point in time
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Pool {
-    pub name: String,
-    pub guid: u64,
-    pub health: String,
-    pub hostname: String,
-    pub hostid: Option<u64>,
-    pub state: String,
-    pub readonly: bool,
-    pub size: String,
-    pub vdev: VDev,
-    pub props: Vec<ZProp>,
-    pub datasets: Vec<Dataset>,
-}
-
-/// A Dataset at a point in time
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Dataset {
-    pub name: String,
-    pub guid: String,
-    pub kind: String,
-    pub props: Vec<ZProp>,
-}
 
 /// Takes a Zfs reference and converts it into a
 /// `Dataset`

--- a/libzfs/src/vdev.rs
+++ b/libzfs/src/vdev.rs
@@ -5,45 +5,10 @@
 extern crate libzfs_sys as sys;
 
 use libzfs_error::{LibZfsError, Result};
+pub use libzfs_types::VDev;
 use nvpair;
 use std::ffi::CStr;
 use std::io::{Error, ErrorKind};
-
-/// Represents vdevs
-/// The enum starts at Root and is recursive.
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Clone)]
-pub enum VDev {
-    Mirror {
-        children: Vec<VDev>,
-        is_log: Option<bool>,
-    },
-    RaidZ {
-        children: Vec<VDev>,
-    },
-    Replacing {
-        children: Vec<VDev>,
-    },
-    Root {
-        children: Vec<VDev>,
-        spares: Vec<VDev>,
-        cache: Vec<VDev>,
-    },
-    Disk {
-        guid: Option<u64>,
-        state: String,
-        path: String,
-        dev_id: Option<String>,
-        phys_path: Option<String>,
-        whole_disk: Option<bool>,
-        is_log: Option<bool>,
-    },
-    File {
-        guid: Option<u64>,
-        state: String,
-        path: String,
-        is_log: Option<bool>,
-    },
-}
 
 pub fn enumerate_vdev_tree(tree: &nvpair::NvList) -> Result<VDev> {
     let tmp = tree.lookup_string(sys::zpool_config_type())?;

--- a/libzfs/src/vdev.rs
+++ b/libzfs/src/vdev.rs
@@ -81,7 +81,8 @@ pub fn enumerate_vdev_tree(tree: &nvpair::NvList) -> Result<VDev> {
         x if x == sys::VDEV_TYPE_DISK => {
             let path = tree
                 .lookup_string(sys::zpool_config_path())?
-                .into_string()?;
+                .into_string()?
+                .into();
             let dev_id = lookup_tree_str(tree, sys::zpool_config_dev_id())?;
             let phys_path = lookup_tree_str(tree, sys::zpool_config_phys_path())?;
             let whole_disk = tree
@@ -102,7 +103,8 @@ pub fn enumerate_vdev_tree(tree: &nvpair::NvList) -> Result<VDev> {
         x if x == sys::VDEV_TYPE_FILE => {
             let path = tree
                 .lookup_string(sys::zpool_config_path())?
-                .into_string()?;
+                .into_string()?
+                .into();
 
             Ok(VDev::File {
                 guid: lookup_guid(tree),

--- a/libzfs/src/zpool.rs
+++ b/libzfs/src/zpool.rs
@@ -170,9 +170,8 @@ impl Drop for Zpool {
 mod tests {
     use super::*;
     use libzfs::Libzfs;
-    use std::ffi::CString;
-    use std::panic;
-    use std::str;
+
+    use std::{ffi::CString, panic, path::PathBuf, str};
 
     fn test_pools<F: Fn(&Vec<Zpool>) -> ()>(f: F) -> ()
     where
@@ -259,6 +258,13 @@ mod tests {
 
     #[test]
     fn test_vdev_tree() {
+        fn create_path_buf(s: &str) -> PathBuf {
+            let mut p = PathBuf::new();
+            p.push(s);
+
+            p
+        }
+
         pool_by_name("test", |p| {
             let (mirror, cache_vdevs, spare_vdevs) = match p.vdev_tree().unwrap() {
                 VDev::Root {
@@ -286,7 +292,7 @@ mod tests {
                 } => {
                     assert!(guid.is_some());
                     assert_eq!(state, "ONLINE");
-                    assert_eq!(path, "/dev/sdb1");
+                    assert_eq!(path, &create_path_buf("/dev/sdb1"));
                     assert!(dev_id.is_some());
                     assert!(phys_path.is_some());
                     assert_eq!(whole_disk, Some(true));
@@ -307,7 +313,7 @@ mod tests {
                 } => {
                     assert!(guid.is_some());
                     assert_eq!(state, "ONLINE");
-                    assert_eq!(path, "/dev/sdc1");
+                    assert_eq!(path, &create_path_buf("/dev/sdc1"));
                     assert!(dev_id.is_some());
                     assert!(phys_path.is_some());
                     assert_eq!(whole_disk, Some(true));
@@ -328,7 +334,7 @@ mod tests {
                 } => {
                     assert!(guid.is_some());
                     assert_eq!(state, "ONLINE");
-                    assert_eq!(path, "/dev/sdd1");
+                    assert_eq!(path, &create_path_buf("/dev/sdd1"));
                     assert!(dev_id.is_some());
                     assert!(phys_path.is_some());
                     assert_eq!(whole_disk, Some(true));
@@ -349,7 +355,7 @@ mod tests {
                 } => {
                     assert!(guid.is_some());
                     assert_eq!(state, "ONLINE");
-                    assert_eq!(path, "/dev/sde1");
+                    assert_eq!(path, &create_path_buf("/dev/sde1"));
                     assert!(dev_id.is_some());
                     assert!(phys_path.is_some());
                     assert_eq!(whole_disk, Some(true));
@@ -370,7 +376,7 @@ mod tests {
                 } => {
                     assert!(guid.is_some());
                     assert_eq!(state, "ONLINE");
-                    assert_eq!(path, "/dev/sdf1");
+                    assert_eq!(path, &create_path_buf("/dev/sdf1"));
                     assert!(dev_id.is_some());
                     assert!(phys_path.is_some());
                     assert_eq!(whole_disk, Some(true));

--- a/libzfs/src/zprop_list.rs
+++ b/libzfs/src/zprop_list.rs
@@ -5,6 +5,8 @@
 extern crate libzfs_sys as sys;
 use std::ffi::CStr;
 
+pub use libzfs_types::ZProp;
+
 #[derive(Debug, PartialEq)]
 pub struct ZpropList {
     head: *mut sys::zprop_list,
@@ -50,10 +52,4 @@ impl ZpropItem {
     pub fn user_prop(&self) -> &CStr {
         unsafe { CStr::from_ptr((*self.raw).pl_user_prop) }
     }
-}
-
-#[derive(Debug, PartialEq, Eq, Hash, Deserialize, Serialize, Clone)]
-pub struct ZProp {
-    pub name: String,
-    pub value: String,
 }


### PR DESCRIPTION
Currently, taking a dep on libzfs means your crate gets linked against
libzfs.so.2 libzpool.so.2 and libnvpair.so.2. Take device-aggregator for
instance, which only takes a dep on libzfs to get shared types:

```shell
$ ldd /usr/bin/device-aggregator
	linux-vdso.so.1 =>  (0x00007ffdba5b8000)
	libzfs.so.2 => not found
	libzpool.so.2 => not found
	libnvpair.so.1 => not found
	libdl.so.2 => /lib64/libdl.so.2 (0x00007f49332af000)
	librt.so.1 => /lib64/librt.so.1 (0x00007f49330a7000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f4932e8b000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f4932c75000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f49328a8000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f4933905000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f49325a6000)
```

We don't need libzfs to be linked in crates that only need type access.
Instead, extract types to their own standalone crate that doesn't have a
dep on libzfs-sys. This way we can get type access without linking to
unneeded shared objects.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>