### PR TITLE
Add repository link to crate metadata where missing

### DIFF
--- a/libzfs-types/Cargo.toml
+++ b/libzfs-types/Cargo.toml
@@ -2,6 +2,7 @@
 name = "libzfs-types"
 version = "0.1.1"
 authors = ["IML Team <iml@whamcloud.com>"]
+repository = "https://github.com/whamcloud/rust-libzfs"
 description = "Shared types for libzfs"
 license = "MIT"
 

--- a/libzfs/Cargo.toml
+++ b/libzfs/Cargo.toml
@@ -2,6 +2,7 @@
 name = "libzfs"
 version = "0.6.15"
 authors = ["IML Team <iml@whamcloud.com>"]
+repository = "https://github.com/whamcloud/rust-libzfs"
 description = "Rust wrapper around libzfs-sys"
 license = "MIT"
 


### PR DESCRIPTION
Cool crate! But was not obvious how to find the repository from the crates.io page, so I thought I could contribute this to help out :)